### PR TITLE
lib/benchmark: Use a single loop for all storage types

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -91,10 +91,6 @@ for item in $(get global install); do
     install_"${item}"
 done
 
-for device in $(get global device); do
-    setup_device "${device}"
-done
-
 for version in $(get global version); do
     install_cowsql "${version}"
     run

--- a/cfg/bmc.cfg
+++ b/cfg/bmc.cfg
@@ -1,13 +1,13 @@
+<% if sudo lsblk /dev/nvme1n1 -n -o MOUNTPOINTS | grep -q -e ^/$; then
+       nvme=/dev/nvme0n1p1
+   else
+       nvme=/dev/nvme1n1p1
+   fi
+-%>
 [global]
 install=utils
 version=stable
 version=main
-device=/dev/nullb0
-<% if sudo lsblk /dev/nvme1n1 -n -o MOUNTPOINTS | grep -q -e ^/$; then -%>
-device=/dev/nvme0n1p1
-<% else -%>
-device=/dev/nvme1n1p1
-<% fi -%>
 
 [nvme]
 lbaf=1
@@ -16,7 +16,10 @@ lbaf=1
 token=<%= $BENCHER_API_TOKEN %>
 
 [benchmark-disk]
-filesystem=ext4
+storage=/dev/nullb0:raw
+storage=/dev/nullb0:ext4
+storage=<%= $nvme %>:raw
+storage=<%= $nvme %>:ext4
 buffer=4096
 buffer=8192
 buffer=65536

--- a/cfg/github.cfg
+++ b/cfg/github.cfg
@@ -7,7 +7,7 @@ version=stable
 token=<%= $BENCHER_API_TOKEN %>
 
 [benchmark-disk]
-directory=.
+storage=.
 buffer=4096
 buffer=8192
 buffer=65536

--- a/cfg/lxc.cfg
+++ b/cfg/lxc.cfg
@@ -2,14 +2,15 @@
 install=utils
 version=main
 version=stable
-device=/dev/nullb0
-device=/dev/nvme0n1p1
 
 [bencher]
 token=<%= $(curl http://lab.linuxcontainers.org/config/cowsql-bencher-raft.token) %>
 
 [benchmark-disk]
-filesystem=ext4
+storage=/dev/nullb0:raw
+storage=/dev/nullb0:ext4
+storage=/dev/nvme0n1p1:ext4
+storage=/dev/nvme0n1p1:ext4
 buffer=4096
 buffer=8192
 buffer=65536


### PR DESCRIPTION
Instead of having different configuration keywords and loops, use a single `storage` config key for all possible storage backends.