### PR TITLE
benchmark/disk: Run as non-root by default

### DIFF
--- a/cfg/bmc.cfg
+++ b/cfg/bmc.cfg
@@ -16,6 +16,7 @@ lbaf=1
 token=<%= $BENCHER_API_TOKEN %>
 
 [benchmark-disk]
+sudo=yes
 storage=/dev/nullb0:raw
 storage=/dev/nullb0:ext4
 storage=<%= $nvme %>:raw

--- a/cfg/github.cfg
+++ b/cfg/github.cfg
@@ -7,6 +7,7 @@ version=stable
 token=<%= $BENCHER_API_TOKEN %>
 
 [benchmark-disk]
+sudo=yes
 storage=.
 buffer=4096
 buffer=8192

--- a/cfg/lxc.cfg
+++ b/cfg/lxc.cfg
@@ -7,6 +7,7 @@ version=stable
 token=<%= $(curl http://lab.linuxcontainers.org/config/cowsql-bencher-raft.token) %>
 
 [benchmark-disk]
+sudo=yes
 storage=/dev/nullb0:raw
 storage=/dev/nullb0:ext4
 storage=/dev/nvme0n1p1:ext4

--- a/lib/benchmark_disk.sh
+++ b/lib/benchmark_disk.sh
@@ -57,6 +57,11 @@ benchmark_disk_target() {
         args="${args} -s ${size}"
     fi
 
+    trace=$(get benchmark-disk trace)
+    if [ -n "${trace}" ]; then
+        args="${args} -t ${trace}"
+    fi
+
     for buffer in $(get benchmark-disk buffer); do
         maybe_bencher_run --project raft --testbed "${tag}" \
                           "sudo $(cmd_raft_benchmark) ${args} -b ${buffer}"

--- a/lib/benchmark_disk.sh
+++ b/lib/benchmark_disk.sh
@@ -8,6 +8,9 @@ cmd_raft_benchmark() {
     if [ "${version}" = "local" ]; then
         cmd=$(get raft path)/tools/$cmd
     fi
+    if [ "$(get benchmark-disk sudo)" = "yes" ]; then
+        cmd="sudo ${cmd}"
+    fi
     if grep -q isolcpus /proc/cmdline; then
         cmd="taskset --cpu-list 3 ${cmd}"
     fi


### PR DESCRIPTION
The benchmark tool is run as regular user by default, but can be optionally run as root if kernel tracing/profiling is desired.