### PR TITLE
Run `raft-benchmark submit` command

### DIFF
--- a/cfg/bmc.cfg
+++ b/cfg/bmc.cfg
@@ -25,3 +25,8 @@ storage=/dev/nullb0:raw
 storage=/dev/nullb0:ext4
 storage=<%= $nvme %>:raw
 storage=<%= $nvme %>:ext4
+
+[benchmark-submit]
+buffer=4096
+storage=/dev/nullb0:ext4
+storage=<%= $nvme %>:ext4

--- a/cfg/bmc.cfg
+++ b/cfg/bmc.cfg
@@ -17,10 +17,11 @@ lbaf=1
 token=<%= $BENCHER_API_TOKEN %>
 
 [benchmark-disk]
+perf=yes
+buffer=4096
+buffer=8192
+buffer=65536
 storage=/dev/nullb0:raw
 storage=/dev/nullb0:ext4
 storage=<%= $nvme %>:raw
 storage=<%= $nvme %>:ext4
-buffer=4096
-buffer=8192
-buffer=65536

--- a/cfg/bmc.cfg
+++ b/cfg/bmc.cfg
@@ -5,6 +5,7 @@
    fi
 -%>
 [global]
+sudo=yes
 install=utils
 version=stable
 version=main
@@ -16,7 +17,6 @@ lbaf=1
 token=<%= $BENCHER_API_TOKEN %>
 
 [benchmark-disk]
-sudo=yes
 storage=/dev/nullb0:raw
 storage=/dev/nullb0:ext4
 storage=<%= $nvme %>:raw

--- a/cfg/github.cfg
+++ b/cfg/github.cfg
@@ -1,5 +1,4 @@
 [global]
-sudo=yes
 install=utils
 version=main
 version=stable

--- a/cfg/github.cfg
+++ b/cfg/github.cfg
@@ -1,4 +1,5 @@
 [global]
+sudo=yes
 install=utils
 version=main
 version=stable
@@ -7,7 +8,6 @@ version=stable
 token=<%= $BENCHER_API_TOKEN %>
 
 [benchmark-disk]
-sudo=yes
 storage=.
 buffer=4096
 buffer=8192

--- a/cfg/github.cfg
+++ b/cfg/github.cfg
@@ -7,7 +7,11 @@ version=stable
 token=<%= $BENCHER_API_TOKEN %>
 
 [benchmark-disk]
-storage=.
 buffer=4096
 buffer=8192
 buffer=65536
+storage=.
+
+[benchmark-submit]
+buffer=4096
+storage=.

--- a/cfg/lxc.cfg
+++ b/cfg/lxc.cfg
@@ -16,3 +16,8 @@ storage=/dev/nullb0:raw
 storage=/dev/nullb0:ext4
 storage=/dev/nvme0n1p1:raw
 storage=/dev/nvme0n1p1:ext4
+
+[benchmark-submit]
+buffer=4096
+storage=/dev/nullb0:ext4
+storage=/dev/nvme0n1p1:ext4

--- a/cfg/lxc.cfg
+++ b/cfg/lxc.cfg
@@ -1,4 +1,5 @@
 [global]
+sudo=yes
 install=utils
 version=main
 version=stable
@@ -7,7 +8,6 @@ version=stable
 token=<%= $(curl http://lab.linuxcontainers.org/config/cowsql-bencher-raft.token) %>
 
 [benchmark-disk]
-sudo=yes
 storage=/dev/nullb0:raw
 storage=/dev/nullb0:ext4
 storage=/dev/nvme0n1p1:raw

--- a/cfg/lxc.cfg
+++ b/cfg/lxc.cfg
@@ -8,10 +8,11 @@ version=stable
 token=<%= $(curl http://lab.linuxcontainers.org/config/cowsql-bencher-raft.token) %>
 
 [benchmark-disk]
+perf=yes
+buffer=4096
+buffer=8192
+buffer=65536
 storage=/dev/nullb0:raw
 storage=/dev/nullb0:ext4
 storage=/dev/nvme0n1p1:raw
 storage=/dev/nvme0n1p1:ext4
-buffer=4096
-buffer=8192
-buffer=65536

--- a/lib/benchmark.sh
+++ b/lib/benchmark.sh
@@ -1,5 +1,7 @@
 . ../lib/benchmark_disk.sh
+. ../lib/benchmark_submit.sh
 
 benchmark() {
     benchmark_disk
+    benchmark_submit
 }

--- a/lib/benchmark_common.sh
+++ b/lib/benchmark_common.sh
@@ -14,3 +14,35 @@ cmd_raft_benchmark() {
     echo "${cmd}"
 }
 
+maybe_bencher_run() {
+    token=$(get bencher token)
+    if [ -n "${token}" ]; then
+        branch=$version
+        bencher run --token "${token}" --branch "${branch}" "$@"
+    else
+        # Do not send reports, only run the command given as last argument.
+        # shellcheck disable=SC1083
+        eval last=\${$#}
+        # shellcheck disable=SC2154
+        ${last}
+    fi
+}
+
+block_driver_name() {
+    device=${1}
+
+    case $device in
+        /dev/nvme*)
+            driver=nvme
+            ;;
+        /dev/nullb*)
+            driver=null
+            ;;
+        *)
+            echo "unknown driver type for $device"
+            exit 1
+            ;;
+    esac
+
+    echo $driver
+}

--- a/lib/benchmark_common.sh
+++ b/lib/benchmark_common.sh
@@ -1,0 +1,16 @@
+version=
+
+cmd_raft_benchmark() {
+    cmd=raft-benchmark
+    if [ "${version}" = "local" ]; then
+        cmd=$(get raft path)/tools/$cmd
+    fi
+    if [ "$(get global sudo)" = "yes" ]; then
+        cmd="sudo ${cmd}"
+    fi
+    if grep -q isolcpus /proc/cmdline; then
+        cmd="taskset --cpu-list 3 ${cmd}"
+    fi
+    echo "${cmd}"
+}
+

--- a/lib/benchmark_disk.sh
+++ b/lib/benchmark_disk.sh
@@ -1,21 +1,8 @@
 . ../lib/setup.sh
+. ../lib/benchmark_common.sh
 
 testbed=
 version=
-
-cmd_raft_benchmark() {
-    cmd=raft-benchmark
-    if [ "${version}" = "local" ]; then
-        cmd=$(get raft path)/tools/$cmd
-    fi
-    if [ "$(get benchmark-disk sudo)" = "yes" ]; then
-        cmd="sudo ${cmd}"
-    fi
-    if grep -q isolcpus /proc/cmdline; then
-        cmd="taskset --cpu-list 3 ${cmd}"
-    fi
-    echo "${cmd}"
-}
 
 maybe_bencher_run() {
     token=$(get bencher token)

--- a/lib/benchmark_disk.sh
+++ b/lib/benchmark_disk.sh
@@ -23,6 +23,13 @@ benchmark_disk_run() {
         maybe_bencher_run --project raft --testbed "${tag}" \
                           "$(cmd_raft_benchmark) ${args} -b ${buffer}"
     done
+
+    perf=$(get benchmark-disk perf)
+    if [ "${perf}" = "yes" ]; then
+        maybe_bencher_run --project raft --testbed "${tag}" \
+                          "$(cmd_raft_benchmark) ${args} -b ${buffer} -p"
+    fi
+
 }
 
 benchmark_disk() {

--- a/lib/benchmark_disk.sh
+++ b/lib/benchmark_disk.sh
@@ -4,39 +4,6 @@
 testbed=
 version=
 
-maybe_bencher_run() {
-    token=$(get bencher token)
-    if [ -n "${token}" ]; then
-        branch=$version
-        bencher run --token "${token}" --branch "${branch}" "$@"
-    else
-        # Do not send reports, only run the command given as last argument.
-        # shellcheck disable=SC1083
-        eval last=\${$#}
-        # shellcheck disable=SC2154
-        ${last}
-    fi
-}
-
-block_driver_name() {
-    device=${1}
-
-    case $device in
-        /dev/nvme*)
-            driver=nvme
-            ;;
-        /dev/nullb*)
-            driver=null
-            ;;
-        *)
-            echo "unknown driver type for $device"
-            exit 1
-            ;;
-    esac
-
-    echo $driver
-}
-
 benchmark_disk_run() {
     tag=$1
     target=$2

--- a/lib/benchmark_submit.sh
+++ b/lib/benchmark_submit.sh
@@ -1,0 +1,41 @@
+. ../lib/setup.sh
+. ../lib/benchmark_common.sh
+
+benchmark_submit_run() {
+    tag=$1
+    target=$2
+    args="submit -d ${target}"
+
+    for buffer in $(get benchmark-submit buffer); do
+        maybe_bencher_run --project raft --testbed "${tag}" \
+                          "$(cmd_raft_benchmark) ${args} -b ${buffer}"
+    done
+}
+
+benchmark_submit() {
+    for storage in $(get benchmark-submit storage); do
+        # Setup
+        if echo "${storage}" | grep -qe ^/dev; then
+            device=$(echo "${storage}" | cut -f 1 -d :)
+            filesystem=$(echo "${storage}" | cut -f 2 -d :)
+            driver=$(block_driver_name "${device}")
+            tag="${testbed}-${driver}-${filesystem}"
+            target=/mnt
+
+            setup_filesystem "${device}" "${filesystem}" /mnt
+            sudo chown "${USER}:${USER}" "${target}"
+        else
+            device="none"
+            tag="${testbed}"
+            target="${storage}"
+        fi
+
+        # Run
+        benchmark_submit_run "${tag}" "${target}"
+
+        # Teardown
+        if [ "${device}" != "none" ]; then
+            sudo umount "${target}"
+        fi
+    done
+}


### PR DESCRIPTION
Run the `raft-benchmark submit` command and report performance metrics to Bencher.

The code has also been refactored to share code between `raft-benchmark submit` and `raft-benchmark disk`.
